### PR TITLE
Add react-track/tracking-formulas

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/gilbox/react-track/issues",
   "scripts": {
     "build-global": "rm -rf build/global && NODE_ENV=production webpack src/index.js build/global/react-track.js && NODE_ENV=production COMPRESS=1 webpack src/index.js build/global/react-track.min.js && echo \"gzipped, the global build is `gzip -c build/global/react-track.min.js | wc -c` bytes\"",
-    "build-npm": "rm -rf build/npm && babel -d build/npm/lib ./src --stage 0 && cp README.md build/npm && find -X build/npm/lib -type d -name __tests__ | xargs rm -rf && node -p 'p=require(\"./package-npm\");JSON.stringify(p,null,2)' > build/npm/package.json",
+    "build-npm": "rm -rf build/npm && babel -d build/npm/lib ./src --stage 0 && cp README.md build/npm && cp tracking-formulas.js build/npm && find -X build/npm/lib -type d -name __tests__ | xargs rm -rf && node -p 'p=require(\"./package-npm\");JSON.stringify(p,null,2)' > build/npm/package.json",
     "examples": "rm -rf examples/js && webpack-dev-server --config examples/webpack.config.js --content-base examples",
     "examples-build": "rm -rf examples/js && webpack --config examples/webpack.build.config.js",
     "test": "jsxhint . && karma start",

--- a/tracking-formulas.js
+++ b/tracking-formulas.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/tracking-formulas');


### PR DESCRIPTION
This is what documented in README.md.

Another option would be to change references to
'react-track/lib/tracking-formulas' in docs but I think having users to reach
`lib/` is not a good API.
