### PR TITLE
ref => trackedRef

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const identity = x => x;
 
 export function createInjector(component) {
   return class Track extends React.Component {
-    static propTypes = { ref: React.PropTypes.func,
+    static propTypes = { trackedRef: React.PropTypes.func,
                          children: React.PropTypes.func.isRequired,
                          formulas: React.PropTypes.array }
 
@@ -19,15 +19,15 @@ export function createInjector(component) {
       const self = this;
 
       this.DecoratedComponent = class extends React.Component {
-        static propTypes = { ref: React.PropTypes.func }
+        static propTypes = { trackedRef: React.PropTypes.func }
 
         render() {
-          const {ref = self.props.ref || identity} = this.props;
+          const {trackedRef = self.props.trackedRef || identity} = this.props;
 
           return <props.component
                     {...self.props}
                     {...this.props}
-                    ref={r => ref(self.nodeRef = r)} />
+                    ref={r => trackedRef(self.nodeRef = r)} />
         }
       }
       this.state = {};


### PR DESCRIPTION
In React 15, refs cannot be set on props. 
This change creates a functionally equivalent 'trackedRef' property instead.
