### PR TITLE
Add missing dependency (chokidar) so demo runs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
     "bundle-loader": "^0.5.4",
+    "chokidar": "^1.6.0",
     "classnames": "^2.1.3",
     "functional-easing": "^1.0.8",
     "jsxhint": "^0.12.1",


### PR DESCRIPTION
`npm run examples` was failing for me without adding this.
